### PR TITLE
Add user and organisation links

### DIFF
--- a/mock-api/account/GET.js
+++ b/mock-api/account/GET.js
@@ -17,12 +17,12 @@ var sample = require("lodash/sample");
 //     );
 // };
 
-// // ADMIN;
-// module.exports = (req, res) => {
-//   res
-//     .status(200)
-//     .json(sample(mockUsers.filter((u) => u.name === "Reyna Simonis")));
-// };
+// ADMIN;
+module.exports = (req, res) => {
+  res
+    .status(200)
+    .json(sample(mockUsers.filter((u) => u.name === "Reyna Simonis")));
+};
 
 // // VCSO - NO services but WITH organisation
 // module.exports = (req, res) => {
@@ -38,12 +38,12 @@ var sample = require("lodash/sample");
 //     .json(sample(mockUsers.filter((u) => u.name === "Tommie Dietrich")));
 // };
 
-// VCSO - NO services but WITH organisation
-module.exports = (req, res) => {
-  res
-    .status(200)
-    .json(sample(mockUsers.filter((u) => u.name === "Melody Zieme")));
-};
+// // VCSO - NO services but WITH organisation
+// module.exports = (req, res) => {
+//   res
+//     .status(200)
+//     .json(sample(mockUsers.filter((u) => u.name === "Melody Zieme")));
+// };
 
 // // VCSO - WITH services but WITHOUT organisations
 // module.exports = (req, res) => {

--- a/mock-api/account/GET.js
+++ b/mock-api/account/GET.js
@@ -17,12 +17,12 @@ var sample = require("lodash/sample");
 //     );
 // };
 
-// // ADMIN;
-// module.exports = (req, res) => {
-//   res
-//     .status(200)
-//     .json(sample(mockUsers.filter((u) => u.name === "Reyna Simonis")));
-// };
+// ADMIN;
+module.exports = (req, res) => {
+  res
+    .status(200)
+    .json(sample(mockUsers.filter((u) => u.name === "Reyna Simonis")));
+};
 
 // // VCSO - NO services but WITH organisation
 // module.exports = (req, res) => {
@@ -31,12 +31,12 @@ var sample = require("lodash/sample");
 //     .json(sample(mockUsers.filter((u) => u.name === "Melody Zieme")));
 // };
 
-// VCSO - WITH services and WITH organisation
-module.exports = (req, res) => {
-  res
-    .status(200)
-    .json(sample(mockUsers.filter((u) => u.name === "Tommie Dietrich")));
-};
+// // VCSO - WITH services and WITH organisation
+// module.exports = (req, res) => {
+//   res
+//     .status(200)
+//     .json(sample(mockUsers.filter((u) => u.name === "Tommie Dietrich")));
+// };
 
 // // VCSO - NO services but WITH organisation
 // module.exports = (req, res) => {

--- a/mock-api/account/GET.js
+++ b/mock-api/account/GET.js
@@ -17,12 +17,12 @@ var sample = require("lodash/sample");
 //     );
 // };
 
-// ADMIN;
-module.exports = (req, res) => {
-  res
-    .status(200)
-    .json(sample(mockUsers.filter((u) => u.name === "Reyna Simonis")));
-};
+// // ADMIN;
+// module.exports = (req, res) => {
+//   res
+//     .status(200)
+//     .json(sample(mockUsers.filter((u) => u.name === "Reyna Simonis")));
+// };
 
 // // VCSO - NO services but WITH organisation
 // module.exports = (req, res) => {
@@ -31,12 +31,12 @@ module.exports = (req, res) => {
 //     .json(sample(mockUsers.filter((u) => u.name === "Melody Zieme")));
 // };
 
-// // VCSO - WITH services and WITH organisation
-// module.exports = (req, res) => {
-//   res
-//     .status(200)
-//     .json(sample(mockUsers.filter((u) => u.name === "Tommie Dietrich")));
-// };
+// VCSO - WITH services and WITH organisation
+module.exports = (req, res) => {
+  res
+    .status(200)
+    .json(sample(mockUsers.filter((u) => u.name === "Tommie Dietrich")));
+};
 
 // // VCSO - NO services but WITH organisation
 // module.exports = (req, res) => {

--- a/mock-api/mockOrganisations.json
+++ b/mock-api/mockOrganisations.json
@@ -2646,8 +2646,8 @@
     }
   },
   {
-    "id": 45914,
-    "name": "Lueilwitz Inc",
+    "id": 66224,
+    "name": "Hackett Inc",
     "created_at": "2020-01-28T00:13:05.560Z",
     "updated_at": "2020-02-07T16:41:48.935Z",
     "submitted_at": "2020-02-26T04:32:20.746Z",

--- a/mock-api/mockUsers.json
+++ b/mock-api/mockUsers.json
@@ -685,10 +685,10 @@
     }
   },
   {
-    "id": 5287,
-    "name": "Madison Kuvalis",
-    "email": "Christop51@gmail.com",
-    "status": "deleted",
+    "id": 81739,
+    "name": "Blaze Harber",
+    "email": "BlazeH@gmail.com",
+    "status": "active",
     "roles": ["admin"],
     "organisation": {
       "id": 2158,

--- a/src/domain/Organisations/ListOrganisations/ListOrganisations.js
+++ b/src/domain/Organisations/ListOrganisations/ListOrganisations.js
@@ -91,7 +91,11 @@ const ListOrganisations = ({ location }) => {
           if (users[key].organisation) {
             const organisationId = users[key].organisation.id;
             const userName = users[key].name;
-            organisationUserObject[organisationId] = userName;
+            const userId = users[key].id;
+            organisationUserObject[organisationId] = {
+              name: userName,
+              id: userId,
+            };
           }
         });
 

--- a/src/domain/Organisations/MyOrganisation/MyOrganisation.js
+++ b/src/domain/Organisations/MyOrganisation/MyOrganisation.js
@@ -68,7 +68,11 @@ const MyOrganisation = () => {
     let localOrganisationUser = {};
     const organisationId = user.organisation.id;
     const userName = user.name;
-    localOrganisationUser[organisationId] = userName;
+    const userId = user.id;
+    localOrganisationUser[organisationId] = {
+      name: userName,
+      id: userId,
+    };
 
     setOrganisationUser(localOrganisationUser);
   }, [user, setOrganisationUser]);

--- a/src/domain/Organisations/OrganisationTable/OrganisationTable.js
+++ b/src/domain/Organisations/OrganisationTable/OrganisationTable.js
@@ -1,10 +1,12 @@
-import React, { useMemo } from "react";
+import React, { useContext, useMemo } from "react";
 import { Link } from "@reach/router";
 import styled from "styled-components";
 import Table from "../../../components/Table/Table";
 import TableActionDropDown from "../../../components/TableActionDropDown/TableActionDropDown";
 import { green, red, yellow } from "../../../settings";
 import { breakpoint } from "../../../utils/breakpoint/breakpoint";
+import UserContext from "../../../context/UserContext/UserContext";
+import { checkIsInternalTeam } from "../../../utils/functions/functions";
 
 const StyledStatus = styled.div`
   background-color: ${(props) => props.status.backgroundColor};
@@ -93,6 +95,12 @@ const OrganisationTable = ({
   showPagination,
   actionWidth,
 }) => {
+  const user = useContext(UserContext)[0];
+
+  const isInternalTeam = checkIsInternalTeam(user.roles);
+
+  // check if is internal member
+
   const columns = useMemo(
     () => [
       {
@@ -115,7 +123,19 @@ const OrganisationTable = ({
         Header: "User",
         accessor: "id",
         Cell: (e) => {
-          return <> {organisationUser[e.value] || "User not found"} </>;
+          if (!isInternalTeam) {
+            return organisationUser[e.value].name;
+          }
+
+          if (organisationUser[e.value]) {
+            return (
+              <Link to={`/users/${organisationUser[e.value].id}/edit`}>
+                {organisationUser[e.value].name}
+              </Link>
+            );
+          } else {
+            return "User not found";
+          }
         },
       },
       {

--- a/src/domain/Organisations/OrganisationTable/OrganisationTable.js
+++ b/src/domain/Organisations/OrganisationTable/OrganisationTable.js
@@ -99,8 +99,6 @@ const OrganisationTable = ({
 
   const isInternalTeam = checkIsInternalTeam(user.roles);
 
-  // check if is internal member
-
   const columns = useMemo(
     () => [
       {

--- a/src/domain/Services/ServiceTable/ServiceTable.js
+++ b/src/domain/Services/ServiceTable/ServiceTable.js
@@ -1,10 +1,12 @@
-import React, { useMemo } from "react";
+import React, { useContext, useMemo } from "react";
 import { Link } from "@reach/router";
 import styled from "styled-components";
 import Table from "../../../components/Table/Table";
 import TableActionDropDown from "../../../components/TableActionDropDown/TableActionDropDown";
 import { green, red, yellow } from "../../../settings";
 import { breakpoint } from "../../../utils/breakpoint/breakpoint";
+import UserContext from "../../../context/UserContext/UserContext";
+import { checkIsInternalTeam } from "../../../utils/functions/functions";
 
 const StyledStatus = styled.div`
   background-color: ${(props) => props.status.backgroundColor};
@@ -67,6 +69,10 @@ const ServiceTable = ({
   actionWidth,
   marginTop,
 }) => {
+  const user = useContext(UserContext)[0];
+
+  const isInternalTeam = checkIsInternalTeam(user.roles);
+
   const columns = useMemo(
     () => [
       {
@@ -83,6 +89,21 @@ const ServiceTable = ({
       {
         Header: "User",
         accessor: "user_name",
+        Cell: (e) => {
+          if (!isInternalTeam) {
+            return e.value;
+          }
+
+          if (e.value) {
+            return (
+              <Link to={`/users/${e.row.original.user_id}/edit`}>
+                {e.value}
+              </Link>
+            );
+          } else {
+            return "User not found";
+          }
+        },
       },
       {
         Header: "Status",

--- a/src/domain/Users/UserTable/UserTable.js
+++ b/src/domain/Users/UserTable/UserTable.js
@@ -29,7 +29,14 @@ const UserTable = ({ data, isLoading, search }) => {
       },
       {
         Header: "Organisation",
-        accessor: "organisation.name",
+        accessor: "organisation",
+        Cell: (e) => {
+          return (
+            <Link to={`/organisations/${e.value.id}/edit`}>
+              <StyledEmailText>{e.value.name}</StyledEmailText>
+            </Link>
+          );
+        },
       },
       {
         Header: "Roles",


### PR DESCRIPTION
**Description**

Add links in table so admins are able to navigate between users/services/organisations from listing tables

**Test instructions** 

- pull this branch
- start app `yarn dev`
- when on the organisations listing page, if you click the name of a user in the table it should take you to that user's profile 
- when on the service listings page (under the 'Listings' tab), if you click the name of 'Blaze Harber' it should take you to their profile (if you click on other users it will not work because the dummy data does not correspond with a user id)
- when on the users listings page (under the 'Users' tab), if you click the organisation 'Hackett Inc' it should take you to the organisation edit form (if you click on other organisations it will not work because the dummy data does not correspond with an organisation id)

. 
- switch to a VCSO user by navigating to **/mock-api/account/GET.js** comment out the 'ADMIN' section and uncomment the 'VCSO - WITH services and WITH organisation' (lines 34 - 39)
- refresh the page 
- look at organisation and service table - users, organisations and services should still be listed but without links 



**Tasks**
https://app.clickup.com/t/a8t41m
https://app.clickup.com/t/a8t3zr
